### PR TITLE
feat: add JSON output format flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
 name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +257,8 @@ dependencies = [
  "anyhow",
  "clap",
  "pulsectl-rs",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -298,6 +306,43 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "serde"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ categories = ["command-line-utilities"]
 anyhow = "1.0.68"
 clap = { version = "4.0.32", features = ["derive"] }
 pulsectl-rs = "0.3.2"
+serde = { version = "^1", features = ["derive"] }
+serde_json = "1.0"


### PR DESCRIPTION
a new flag `-j` or `--json` to be able to list the devices as JSON use case: a use with jq in a script

example: 
```
> cargo run -- list --json | jq
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/pads list --json`
[
  {
    "is_current": false,
    "index": 1,
    "description": "Built-in Audio Analog Stereo"
  },
  {
    "is_current": true,
    "index": 9,
    "description": "fr-lefuturiste-audio"
  }
]
```