### PR TITLE
fix: filter out unplugged devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libpulse-binding"
-version = "2.27.1"
+version = "2.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1745b20bfc194ac12ef828f144f0ec2d4a7fe993281fa3567a0bd4969aee6890"
+checksum = "ed3557a2dfc380c8f061189a01c6ae7348354e0c9886038dc6c171219c08eaff"
 dependencies = [
  "bitflags",
  "libc",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "libpulse-sys"
-version = "1.20.1"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2191e6880818d1df4cf72eac8e91dce7a5a52ba0da4b2a5cdafabc22b937eadb"
+checksum = "bc19e110fbf42c17260d30f6d3dc545f58491c7830d38ecb9aaca96e26067a9b"
 dependencies = [
  "libc",
  "num-derive",
@@ -256,6 +256,7 @@ version = "0.2.6"
 dependencies = [
  "anyhow",
  "clap",
+ "libpulse-sys",
  "pulsectl-rs",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ homepage = "https://github.com/dogue/pads"
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.0.32", features = ["derive"] }
+libpulse-sys = "1.21.0"
 pulsectl-rs = "0.3.2"
 serde = { version = "^1", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
If the port is unplugged as in some HDMI connections, `pads next` fails silently. Not sure much pads can do since pactl set-default-sink fails as well. This skips over the devices where the port is unplugged.